### PR TITLE
Use checksum of Composer lock file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ jobs:
       - run: composer self-update
       - restore_cache:
           keys:
-            - composer-v1-{{ checksum "composer.json" }}
+            - composer-v1-{{ checksum "composer.lock" }}
             - composer-v1-
       - run: composer install -n --prefer-dist
       - save_cache:
-          key: composer-v1-{{ checksum "composer.json" }}
+          key: composer-v1-{{ checksum "composer.lock" }}
           paths:
             - vendor
       - run: touch storage/testing.sqlite


### PR DESCRIPTION
I could be wrong here, but I suspect you would want to use the checksum of the lock file for caching. The reason being that if one was to run `composer update` on the same `composer.json` file they could get different (newer) versions of the dependencies. The lock file is the definitive source of the installed dependency versions.