### PR TITLE
Update symfony/http-foundation for CVE-2019-10913 and CVE-2019-18888

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
   "require": {
     "laravel/framework": "5.4.*",
     "flow/jsonpath": "^0.2.4",
-    "fzaninotto/faker": "~1.4"
+    "fzaninotto/faker": "~1.4",
+    "symfony/http-foundation": "3.4.35"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Updating composer.json to set minimum version for symfony/http-foundation
to resolve the two CVE's

CVE-2019-10913 critical severity
https://github.com/advisories/GHSA-x92h-wmg2-6hp7
Vulnerable versions: >= 3.0.0, < 3.4.26
Patched version: 3.4.26

CVE-2019-18888 moderate severity
https://github.com/advisories/GHSA-xhh6-956q-4q69
Vulnerable versions: >= 3.0.0, < 3.4.35
Patched version: 3.4.35